### PR TITLE
Props validation to prevent page crashing

### DIFF
--- a/labtool2.0/src/components/pages/Courses.js
+++ b/labtool2.0/src/components/pages/Courses.js
@@ -19,7 +19,7 @@ export class Courses extends Component {
       <div className="Courses">
         <Container>
           <Header as="h2">Courses</Header>
-          {this.props.loading.loading ? (
+          {this.props.loading.loading || !Array.isArray(this.props.courseInstance) ? (
             <Loader active />
           ) : (
             <Table singleLine color="yellow">

--- a/labtool2.0/src/components/pages/ManageTags.js
+++ b/labtool2.0/src/components/pages/ManageTags.js
@@ -132,12 +132,14 @@ export class ManageTags extends React.Component {
           <br />
           {this.props.loading.loading ? (
             <Loader active />
-          ) : (
+          ) : this.props.tags.tags ? (
             this.props.tags.tags.map(tag => (
               <button key={tag.id} className={`mini ui ${tag.color} button`} onClick={this.modifyTag(tag.name, tag.color)}>
                 {tag.name}
               </button>
             ))
+          ) : (
+            <div />
           )}
           <br />
           <br />


### PR DESCRIPTION
### Short description
Before, if you were on the course page, (de)activated the course, then went to courses page, it crashed (at least sometimes). Also, if you refreshed when being on the manage tags page, it crashed. This branch adds props validation for those pages so they don't crash anymore.

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added actual code.
- [ ] produced clean code.
- [X] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [ ] test(s) that actually pass.
