### PR TITLE
Add Markdown note and preview

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -56,6 +56,7 @@
     "dropdb": "node_modules/.bin/sequelize db:drop",
     "import_courses": "echo 'I expect to have backend running on localhost port 3001\n\n';curl -k -X POST -H 'Content-Type: application/json' http://localhost:3001/api/courseinstances/update",
     "test": "ADMIN_PW=test NODE_ENV=test ./node_modules/.bin/mocha --exit -R spec",
+    "lint": "./node_modules/.bin/eslint .",
     "create_test_db": "./node_modules/.bin/sequelize db:drop --env test; ./node_modules/.bin/sequelize db:create --env test; ./node_modules/.bin/sequelize db:migrate --env test;",
     "drop_test_db": "./node_modules/.bin/sequelize db:drop --env test; ",
     "add_test_data": "./node_modules/.bin/sequelize db:seed:all",

--- a/backend/server/controllers/courseinstances.js
+++ b/backend/server/controllers/courseinstances.js
@@ -550,6 +550,10 @@ module.exports = {
       }
       request(options, function(err, resp, body) {
         const json = JSON.parse(body)
+        if (!json.forEach) {
+          logger.error(json)
+          return
+        }
         json.forEach(instance => {
           CourseInstance.findOrCreate({
             attributes: {

--- a/labtool2.0/package.json
+++ b/labtool2.0/package.json
@@ -28,6 +28,7 @@
     "debug": "react-scripts --inspect=0.0.0.0:9230 start .env.development.local",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
+    "lint": "./node_modules/.bin/eslint .",
     "tryTest": "npm run test a q",
     "eject": "react-scripts eject"
   },

--- a/labtool2.0/src/components/MarkdownTextArea.js
+++ b/labtool2.0/src/components/MarkdownTextArea.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types'
 import { Accordion, Form, Icon } from 'semantic-ui-react'
 import ReactMarkdown from 'react-markdown'
 
+// replace Form.TextArea with FormMarkdownTextArea
+// only adds preview and info line, Markdown needs to be supported by code
+// viewing the text outside the text area
 export class FormMarkdownTextArea extends React.Component {
   state = { activeIndex: -1, textValue: this.props.defaultValue ? this.props.defaultValue : '' }
 

--- a/labtool2.0/src/components/MarkdownTextArea.js
+++ b/labtool2.0/src/components/MarkdownTextArea.js
@@ -1,9 +1,10 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Accordion, Form, Icon } from 'semantic-ui-react'
 import ReactMarkdown from 'react-markdown'
 
 export class FormMarkdownTextArea extends React.Component {
-  state = { activeIndex: -1, textValue: this.props.defaultValue || '' }
+  state = { activeIndex: -1, textValue: this.props.defaultValue ? this.props.defaultValue : '' }
 
   handleClick = (e, titleProps) => {
     const { index } = titleProps
@@ -36,4 +37,8 @@ export class FormMarkdownTextArea extends React.Component {
       </div>
     )
   }
+}
+
+FormMarkdownTextArea.propTypes = {
+  defaultValue: PropTypes.string
 }

--- a/labtool2.0/src/components/pages/BrowseReviews.js
+++ b/labtool2.0/src/components/pages/BrowseReviews.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import { Button, Card, Accordion, Icon, Form, Comment, Input, Popup, Loader, Label } from 'semantic-ui-react'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
-import { FormMarkdownTextArea } from './MarkdownTextArea'
 import { createOneComment } from '../../services/comment'
 import { getOneCI, coursePageInformation } from '../../services/courseInstance'
 import { gradeCodeReview } from '../../services/codeReview'
@@ -12,6 +11,7 @@ import { resetLoading } from '../../reducers/loadingReducer'
 import { trimDate } from '../../util/format'
 
 import BackButton from '../BackButton'
+import { FormMarkdownTextArea } from '../MarkdownTextArea'
 
 /**
  * Maps all comments from a single instance from coursePage reducer

--- a/labtool2.0/src/components/pages/BrowseReviews.js
+++ b/labtool2.0/src/components/pages/BrowseReviews.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { Button, Card, Accordion, Icon, Form, Comment, Input, Popup, Loader, Label } from 'semantic-ui-react'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
+import { FormMarkdownTextArea } from './MarkdownTextArea'
 import { createOneComment } from '../../services/comment'
 import { getOneCI, coursePageInformation } from '../../services/courseInstance'
 import { gradeCodeReview } from '../../services/codeReview'
@@ -203,7 +204,7 @@ export class BrowseReviews extends Component {
                       )}
                     </Comment.Group>
                     <Form reply onSubmit={this.handleSubmit} name={weeks.id} id={weeks.id}>
-                      <Form.TextArea name="content" placeholder="Your comment..." defaultValue="" />
+                      <FormMarkdownTextArea name="content" placeholder="Your comment..." defaultValue="" />
                       <Form.Checkbox label="Add comment for instructors only" name="hidden" />
                       <Button content="Add Reply" labelPosition="left" icon="edit" primary />
                     </Form>
@@ -311,7 +312,7 @@ export class BrowseReviews extends Component {
                       )}
                     </Comment.Group>
                     <Form reply onSubmit={this.handleSubmit} name={finalWeek.id} id={finalWeek.id}>
-                      <Form.TextArea name="content" placeholder="Your comment..." defaultValue="" />
+                      <FormMarkdownTextArea name="content" placeholder="Your comment..." defaultValue="" />
                       <Form.Checkbox label="Add comment for instructors only" name="hidden" />
                       <Button content="Add Reply" labelPosition="left" icon="edit" primary />
                     </Form>

--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Accordion, Button, Table, Card, Input, Form, Comment, Header, Label, Message, Icon, Dropdown, Popup, Loader } from 'semantic-ui-react'
 import { Link } from 'react-router-dom'
 import { connect } from 'react-redux'
+import { FormMarkdownTextArea } from './MarkdownTextArea'
 import { createOneComment } from '../../services/comment'
 import { getOneCI, coursePageInformation } from '../../services/courseInstance'
 import { associateTeacherToStudent } from '../../services/assistant'
@@ -391,7 +392,7 @@ export class CoursePage extends React.Component {
                     )}
                   </Comment.Group>
                   <Form reply onSubmit={this.handleSubmit} name={week.id} id={week.id}>
-                    <Form.TextArea name="content" placeholder="Your comment..." defaultValue="" />
+                    <FormMarkdownTextArea name="content" placeholder="Your comment..." defaultValue="" />
                     <Button content="Add Reply" labelPosition="left" icon="edit" primary />
                   </Form>
                 </Accordion.Content>

--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { Accordion, Button, Table, Card, Input, Form, Comment, Header, Label, Message, Icon, Dropdown, Popup, Loader } from 'semantic-ui-react'
 import { Link } from 'react-router-dom'
 import { connect } from 'react-redux'
-import { FormMarkdownTextArea } from './MarkdownTextArea'
 import { createOneComment } from '../../services/comment'
 import { getOneCI, coursePageInformation } from '../../services/courseInstance'
 import { associateTeacherToStudent } from '../../services/assistant'
@@ -23,6 +22,8 @@ import {
 } from '../../reducers/coursePageLogicReducer'
 import { resetLoading } from '../../reducers/loadingReducer'
 import { trimDate } from '../../util/format'
+
+import { FormMarkdownTextArea } from '../MarkdownTextArea'
 
 export class CoursePage extends React.Component {
   handleClick = (e, titleProps) => {

--- a/labtool2.0/src/components/pages/MarkdownTextArea.js
+++ b/labtool2.0/src/components/pages/MarkdownTextArea.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Accordion, Form, Icon } from 'semantic-ui-react'
+import ReactMarkdown from 'react-markdown'
+
+export class FormMarkdownTextArea extends React.Component {
+  state = { activeIndex: -1, textValue: this.props.defaultValue || '' }
+
+  handleClick = (e, titleProps) => {
+    const { index } = titleProps
+    const { activeIndex } = this.state
+    const newIndex = activeIndex === index ? -1 : index
+
+    this.setState({ ...this.state, activeIndex: newIndex })
+  }
+
+  handleChange = (e, data) => {
+    this.setState({ ...this.state, textValue: data.value })
+  }
+
+  render() {
+    const { activeIndex, textValue } = this.state
+
+    return (
+      <div>
+        <Form.TextArea onInput={this.handleChange.bind(this)} {...this.props} />
+        <p><i>This field supports <a href="https://guides.github.com/features/mastering-markdown/" target="_blank" rel="noopener noreferrer">Markdown</a>.</i></p>
+        <Accordion key fluid styled>
+          <Accordion.Title active={0 === activeIndex} index={0} onClick={this.handleClick.bind(this)}>
+            <Icon name="dropdown" />
+            Preview Markdown
+          </Accordion.Title>
+          <Accordion.Content active={activeIndex === 0}>
+            <ReactMarkdown source={textValue} />
+          </Accordion.Content>
+        </Accordion>
+      </div>
+    )
+  }
+}

--- a/labtool2.0/src/components/pages/ReviewStudent.js
+++ b/labtool2.0/src/components/pages/ReviewStudent.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { Button, Form, Input, Grid, Card, Loader, Icon } from 'semantic-ui-react'
 import { Link, Redirect } from 'react-router-dom'
 import { connect } from 'react-redux'
+import { FormMarkdownTextArea } from './MarkdownTextArea'
 import { createOneWeek } from '../../services/week'
 import { getOneCI, coursePageInformation } from '../../services/courseInstance'
 import { clearNotifications } from '../../reducers/notificationReducer'
@@ -63,7 +64,7 @@ export class ReviewStudent extends Component {
     /* The below line is as hacky as it is because functional elements cannot directly have refs.
     * This abomination somehow accesses a textarea that is a child of a div that holds the ref.
     */
-    this.reviewTextRef.current.children[0].children.comment.value = e.target.text.value
+    this.reviewTextRef.current.getElementsByTagName('textarea')[0].value = e.target.text.value
   }
 
   render() {
@@ -148,8 +149,8 @@ export class ReviewStudent extends Component {
                   <label> Feedback </label>
                   <Form.Group inline unstackable style={{ textAlignVertical: 'top' }}>
                     <div ref={this.reviewTextRef}>
-                      {/*Do not add anything else to this div. If you do, you'll break this.copyChecklistOutput.*/}
-                      <Form.TextArea defaultValue={weekData[0] ? weekData[0].feedback : ''} name="comment" style={{ width: '500px', height: '250px' }} />
+                      {/*Do not add any other textareas to this div. If you do, you'll break this.copyChecklistOutput.*/}
+                      <FormMarkdownTextArea defaultValue={weekData[0] ? weekData[0].feedback : ''} name="comment" style={{ width: '500px', height: '250px' }} />
                     </div>
                   </Form.Group>
                   <Form.Field>

--- a/labtool2.0/src/components/pages/ReviewStudent.js
+++ b/labtool2.0/src/components/pages/ReviewStudent.js
@@ -2,13 +2,14 @@ import React, { Component } from 'react'
 import { Button, Form, Input, Grid, Card, Loader, Icon } from 'semantic-ui-react'
 import { Link, Redirect } from 'react-router-dom'
 import { connect } from 'react-redux'
-import { FormMarkdownTextArea } from './MarkdownTextArea'
 import { createOneWeek } from '../../services/week'
 import { getOneCI, coursePageInformation } from '../../services/courseInstance'
 import { clearNotifications } from '../../reducers/notificationReducer'
 import { toggleCheck, resetChecklist } from '../../reducers/weekReviewReducer'
 import { resetLoading, addRedirectHook } from '../../reducers/loadingReducer'
 import store from '../../store'
+
+import { FormMarkdownTextArea } from '../MarkdownTextArea'
 
 /**
  *  The page which is used by teacher to review submissions,.

--- a/labtool2.0/src/tests/__snapshots__/ReviewStudent.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/ReviewStudent.test.js.snap
@@ -87,9 +87,7 @@ exports[`<ReviewStudent /> ReviewStudent Component should render correctly 1`] =
             unstackable={true}
           >
             <div>
-              <FormTextArea
-                as={[Function]}
-                control={[Function]}
+              <FormMarkdownTextArea
                 defaultValue="Hienoa työtä!"
                 name="comment"
                 style={


### PR DESCRIPTION
### Short description
This adds a note to all text areas that support Markdown as well as a preview, addressing #531 and #532.

Other changes include adding `npm run lint` to `package.json` ease ESLint tests from console as well as fixing `copyChecklistOutput` a bit (it's still messy and needs to be refactored).

### DoD
I have:
- [x] added actual code.
- [x] produced clean code.
- [x] code that actually does what it should.
- [x] documented the code or added documentation to the wiki.
- [x] added or modified test(s).
- [x] test(s) that actually pass.

### Notes
The new code passes ESLint. Old code does not; see #577.
