### PR TITLE
Dependabot configuration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,7 @@
+version: 1
+
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    target_branch: "trunk"


### PR DESCRIPTION
This PR configures Dependabot. It now creates PR's against the `trunk`-branch instead of `master`.

I think it'll only work once the config has been pushed to `master`. Dependabot should then remove the existing PR's and create them again, pointing to the right branch.