### PR TITLE
prefill the github field with 'https://github.com/' in register page

### DIFF
--- a/labtool2.0/src/components/pages/RegisterPage.js
+++ b/labtool2.0/src/components/pages/RegisterPage.js
@@ -84,7 +84,7 @@ export class RegisterPage extends Component {
 
               <Form.Group inline>
                 <label style={{ width: '100px', textAlign: 'left' }}>GitHub link</label>
-                <Input icon="github" iconPosition="left" type="url" className="form-control2" name="github" placeholder="https://github.com/myaccount/myrepo" required style={{ minWidth: '30em' }} />
+                <Input icon="github" iconPosition="left" type="url" className="form-control2" name="github" defaultValue="https://github.com/" required style={{ minWidth: '30em' }} />
               </Form.Group>
 
               <Form.Field>

--- a/labtool2.0/src/tests/__snapshots__/RegisterPage.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/RegisterPage.test.js.snap
@@ -76,10 +76,10 @@ exports[`<Register /> RegisterPage Component should render correctly 1`] = `
           </label>
           <Input
             className="form-control2"
+            defaultValue="https://github.com/"
             icon="github"
             iconPosition="left"
             name="github"
-            placeholder="https://github.com/myaccount/myrepo"
             required={true}
             style={
               Object {


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
#372 Prefill the Github field with https://github.com/ when a user registers his project

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [x] added or modified test(s).
- [x] test(s) that actually pass.
