### PR TITLE
Optimze Dockerfile to use -slim image, re-order steps to use cache la…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,22 @@
-FROM node:8
-ADD ./labtool2.0 /code
+FROM node:8-slim
+
+#Install serve package
+RUN npm install -g serve@6.5.8
+
+#Switch to workdir and copy contents
 WORKDIR /code
+COPY ./labtool2.0 ./
 COPY ./labtool2.0/package.json ../
+
+#Run ci and build
 RUN npm ci
 RUN npm run build
-RUN npm install -g serve@6.5.8
+
+#Export path properly
 ENV PATH=".:${PATH}"
+
+#Expose listen port
 EXPOSE 3000
-CMD [ "serve", "-p", "3000", "-s", "build" ]
+
+ENTRYPOINT ["serve"]
+CMD [ "-p", "3000", "-s", "build" ]


### PR DESCRIPTION
…yers better

### Short description
Optimze `Dockerfile` so it builds faster and results in a smaller image, fixes  #689

Original image and new image size comparision:

```
labtool                                 new                                                    271e7e5ad5d4        14 minutes ago      379MB
labtool                                 orig                                                   018bd6316fa0        20 minutes ago      1.14GB
```

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] added actual code.
- [ ] produced clean code that passes ESLint.
- [ ] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [ ] test(s) that actually pass.
- [x] works in trunk branch <!-- remove this line if your PR is not against master -->
