### PR TITLE
feat/The teacher can see details of a student's previous participation

### DIFF
--- a/labtool2.0/src/components/pages/BrowseReviews.js
+++ b/labtool2.0/src/components/pages/BrowseReviews.js
@@ -17,6 +17,7 @@ import useLegacyState from '../../hooks/legacyState'
 import BackButton from '../BackButton'
 import LabtoolComment from '../LabtoolComment'
 import { FormMarkdownTextArea } from '../MarkdownTextArea'
+import { getAcademicYear } from '../../util/format'
 
 /**
  * Maps all comments from a single instance from coursePage reducer
@@ -144,16 +145,17 @@ export const BrowseReviews = props => {
   //get student's other participations in the same course
   const renderStudentPreviousParticipation = () => {
     const previousParticipations = props.studentInstanceToBeReviewed.filter(courseInstance => courseInstance.ohid.includes(props.courseId.substring(0, 8)) && courseInstance.ohid !== props.courseId)
+
     if (previousParticipations.length === 0) {
       return <p className="noPrevious">Has not taken part in this course before</p>
     }
     return (
       <div className="hasPrevious">
-        <p className style={{ color: 'red' }}>
-          Has taken this course before
-        </p>
+        <p style={{ color: 'red' }}>Has taken this course before</p>
         {previousParticipations.map(participation => (
-          <p key={participation.id}>{createCourseIdWithYearAndTerm(participation.ohid, participation.start)}</p>
+          <Link key={participation.id} to={`/labtool/browsereviews/${participation.ohid}/${participation.courseInstances[0].id}`} target="_blank">
+            <Popup content="click to open a new tab to see the details" trigger={<p>{createCourseIdWithYearAndTerm(participation.ohid, participation.start)}</p>} />
+          </Link>
         ))}
       </div>
     )
@@ -366,7 +368,10 @@ export const BrowseReviews = props => {
         <div>
           <BackButton preset="coursePage" />
           <Link to={`/labtool/courses/${props.selectedInstance.ohid}`} style={{ textAlign: 'center' }}>
-            <h2> {props.selectedInstance.name} </h2>
+            <h2>
+              {' '}
+              {props.selectedInstance.name} ({getAcademicYear(props.selectedInstance.start)}){' '}
+            </h2>
           </Link>
           {createHeaders(props.courseData, props.studentInstance)}
         </div>

--- a/labtool2.0/src/tests/BrowseReviews.test.js
+++ b/labtool2.0/src/tests/BrowseReviews.test.js
@@ -226,9 +226,13 @@ describe('<BrowseReviews />', () => {
             start: '2017-03-11T21:00:00.000Z',
             end: '2017-04-29T21:00:00.000Z',
             active: false,
-            ohid: 'TKT20010.2017.K.A.1'
+            ohid: 'TKT20010.2017.K.A.1',
+            courseInstances: [{ id: 1 }]
           },
-          coursePage
+          {
+            ...coursePage,
+            courseInstances: [{ id: 10011 }]
+          }
         ]
         wrapper = shallow(
           <BrowseReviews
@@ -251,7 +255,11 @@ describe('<BrowseReviews />', () => {
           />
         )
         expect(wrapper.find('.hasPrevious').text()).toContain('Has taken this course before')
-        expect(wrapper.find('.hasPrevious').text()).toContain('TKT20010 16-17 4.period')
+        const popup = wrapper
+          .find('.hasPrevious')
+          .find('Link')
+          .find('Popup')
+        expect(popup.props()).toHaveProperty('trigger', <p>TKT20010 16-17 4.period</p>)
       })
       it('student can be marked as dropped and non-dropped', () => {
         wrapper.find({ children: 'Mark as dropped' }).simulate('click')

--- a/labtool2.0/src/tests/__snapshots__/BrowseReviews.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/BrowseReviews.test.js.snap
@@ -27,7 +27,9 @@ exports[`<BrowseReviews /> BrowseReviews Component should render correctly 1`] =
       <h2>
          
         Aineopintojen harjoitustyö: Tietorakenteet ja algoritmit
-         
+         (
+        17-18
+        ) 
       </h2>
     </Link>
     <Card

--- a/labtool2.0/src/tests/__snapshots__/BrowseReviews.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/BrowseReviews.test.js.snap
@@ -29,7 +29,8 @@ exports[`<BrowseReviews /> BrowseReviews Component should render correctly 1`] =
         Aineopintojen harjoitustyö: Tietorakenteet ja algoritmit
          (
         17-18
-        ) 
+        )
+         
       </h2>
     </Link>
     <Card


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
#680 The teacher can click a student's previous participation shown in the BrowswReview page to open a new tab to see details
### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [x] added or modified test(s).
- [x] test(s) that actually pass.
