### PR TITLE
Allow courses and material URL to be set to be empty

### DIFF
--- a/backend/server/controllers/courseinstances.js
+++ b/backend/server/controllers/courseinstances.js
@@ -428,7 +428,7 @@ module.exports = {
             })
             StudentInstance.find({
               where: {
-                userId: userId,
+                userId,
                 courseInstanceId: course.id
               }
             }).then((targetStudent) => {
@@ -512,8 +512,8 @@ module.exports = {
                 currentWeek: req.body.currentWeek || courseInstance.currentWeek,
                 finalReview: req.body.finalReview,
                 currentCodeReview: req.body.newCr.length === 0 ? '{}' : req.body.newCr,
-                coursesPage: req.body.coursesPage || courseInstance.coursesPage,
-                courseMaterial: req.body.courseMaterial || courseInstance.courseMaterial
+                coursesPage: typeof req.body.coursesPage === 'string' ? req.body.coursesPage : courseInstance.coursesPage,
+                courseMaterial: typeof req.body.courseMaterial === 'string' ? req.body.coursesMaterial : courseInstance.courseMaterial
               })
               .then(updatedCourseInstance => res.status(200).send(updatedCourseInstance))
               .catch((error) => {


### PR DESCRIPTION
### Short description
Fixes a bug where courses and material URLs could not be set to be empty again after being set to something else

### DoD
I have:
- [ ] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [x] test(s) that actually pass.
