### PR TITLE
Fix/not show later courses

### DIFF
--- a/labtool2.0/src/components/pages/BrowseReviews.js
+++ b/labtool2.0/src/components/pages/BrowseReviews.js
@@ -144,8 +144,9 @@ export const BrowseReviews = props => {
 
   //get student's other participations in the same course
   const renderStudentPreviousParticipation = () => {
-    const previousParticipations = props.studentInstanceToBeReviewed.filter(courseInstance => courseInstance.ohid.includes(props.courseId.substring(0, 8)) && courseInstance.ohid !== props.courseId)
-
+    const previousParticipations = props.studentInstanceToBeReviewed.filter(
+      courseInstance => courseInstance.ohid.includes(props.courseId.substring(0, 8)) && new Date(courseInstance.start) < new Date(props.selectedInstance.start)
+    )
     if (previousParticipations.length === 0) {
       return <p className="noPrevious">Has not taken part in this course before</p>
     }

--- a/labtool2.0/src/tests/BrowseReviews.test.js
+++ b/labtool2.0/src/tests/BrowseReviews.test.js
@@ -234,26 +234,8 @@ describe('<BrowseReviews />', () => {
             courseInstances: [{ id: 10011 }]
           }
         ]
-        wrapper = shallow(
-          <BrowseReviews
-            getOneCI={mockFn}
-            coursePageInformation={mockFn}
-            getCoursesByStudentId={mockFn}
-            courseData={courseData}
-            selectedInstance={coursePage}
-            studentInstanceToBeReviewed={studentWithPreviousParticipation}
-            courseId={coursePage.ohid}
-            studentInstance={'10011'}
-            loading={loading}
-            resetLoading={mockFn}
-            initialLoading={false}
-            updateStudentProjectInfo={mockFn}
-            user={{}}
-            createOneComment={mockFn}
-            gradeCodeReview={mockFn}
-            sendEmail={mockFn}
-          />
-        )
+
+        wrapper.setProps({ studentInstanceToBeReviewed: studentWithPreviousParticipation, studentInstanceId: '10011' })
         expect(wrapper.find('.hasPrevious').text()).toContain('Has taken this course before')
         const popup = wrapper
           .find('.hasPrevious')


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
#719 "has taken this course before" shouldn't show later course instances in BrowseReview page

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [x] added or modified test(s).
- [x] test(s) that actually pass.
