### PR TITLE
Improve other participation

### DIFF
--- a/labtool2.0/src/components/pages/BrowseReviews.js
+++ b/labtool2.0/src/components/pages/BrowseReviews.js
@@ -187,18 +187,16 @@ export const BrowseReviews = props => {
 
   //get student's other participations in the same course
   const renderStudentPreviousParticipation = () => {
-    const previousParticipations = props.studentInstanceToBeReviewed.filter(
-      courseInstance => courseInstance.ohid.includes(props.courseId.substring(0, 8)) && new Date(courseInstance.start) < new Date(props.selectedInstance.start)
-    )
+    const previousParticipations = props.studentInstanceToBeReviewed.filter(courseInstance => courseInstance.ohid.includes(props.courseId.substring(0, 8)) && courseInstance.ohid !== props.courseId)
     if (previousParticipations.length === 0) {
-      return <p className="noPrevious">Has not taken part in this course before</p>
+      return <p className="noOther">Has no other participation in this course</p>
     }
     return (
-      <div className="hasPrevious">
-        <p style={{ color: 'red' }}>Has taken this course before</p>
+      <div className="hasOther">
+        <p style={{ color: 'red' }}>Has taken this course in other periods</p>
         {previousParticipations.map(participation => (
-          <Link key={participation.id} to={`/labtool/browsereviews/${participation.ohid}/${participation.courseInstances[0].id}`} target="_blank">
-            <Popup content="click to open a new tab to see the details" trigger={<p>{createCourseIdWithYearAndTerm(participation.ohid, participation.start)}</p>} />
+          <Link key={participation.id} to={`/labtool/browsereviews/${participation.ohid}/${participation.courseInstances[0].id}`}>
+            <Popup content="click to see the details" trigger={<p>{createCourseIdWithYearAndTerm(participation.ohid, participation.start)}</p>} />
           </Link>
         ))}
       </div>

--- a/labtool2.0/src/reducers/studentInstanceReducer.js
+++ b/labtool2.0/src/reducers/studentInstanceReducer.js
@@ -24,7 +24,8 @@ const studentInstancereducer = (store = INITIAL_STATE, action) => {
     case 'STUDENT_COURSES_GET_ALL_BY_USERID_SUCCESS':
       return action.response
     case 'STUDENT_COURSE_CREATE_ONE_SUCCESS':
-      return [...action.response]
+      //return [...action.response]
+      return store
     case 'STUDENT_PROJECT_INFO_UPDATE_SUCCESS':
       return store // [...action.response]
     default:

--- a/labtool2.0/src/tests/BrowseReviews.test.js
+++ b/labtool2.0/src/tests/BrowseReviews.test.js
@@ -234,9 +234,9 @@ describe('<BrowseReviews />', () => {
         expect(wrapper.find('.studentCard').exists()).toEqual(true)
       })
       it('when student participates the course first time', () => {
-        expect(wrapper.find('.noPrevious').text()).toEqual('Has not taken part in this course before')
+        expect(wrapper.find('.noOther').text()).toEqual('Has no other participation in this course')
       })
-      it('when student participate previous instances of the course', () => {
+      it('when student participate other instances of the course', () => {
         const studentWithPreviousParticipation = [
           {
             ...coursePage,
@@ -255,9 +255,9 @@ describe('<BrowseReviews />', () => {
         ]
 
         wrapper.setProps({ studentInstanceToBeReviewed: studentWithPreviousParticipation, studentInstanceId: '10011' })
-        expect(wrapper.find('.hasPrevious').text()).toContain('Has taken this course before')
+        expect(wrapper.find('.hasOther').text()).toContain('Has taken this course in other periods')
         const popup = wrapper
-          .find('.hasPrevious')
+          .find('.hasOther')
           .find('Link')
           .find('Popup')
         expect(popup.props()).toHaveProperty('trigger', <p>TKT20010 2016-2017 P.IV</p>)

--- a/labtool2.0/src/tests/__snapshots__/BrowseReviews.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/BrowseReviews.test.js.snap
@@ -74,9 +74,9 @@ exports[`<BrowseReviews /> BrowseReviews Component should render correctly 1`] =
           </a>
           <br />
           <p
-            className="noPrevious"
+            className="noOther"
           >
-            Has not taken part in this course before
+            Has no other participation in this course
           </p>
         </div>
         <Button


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
#756 
- No new tab when checking details of other participation
- Also show later participation and teacher can return to the current instance from a previous one
### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [x] added or modified test(s).
- [x] test(s) that actually pass.