### PR TITLE
Show maximum points to student

### DIFF
--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -236,16 +236,27 @@ export const CoursePage = props => {
     return <LabtoolComment key={comment.id} comment={comment} allowNotify={userIsCommandSender} sendCommentEmail={sendEmail(comment.id)} />
   }
 
+  const getMaximumPoints = week => {
+    const checklist = props.selectedInstance.checklists.find(checkl => checkl.week === week)
+    if (checklist === undefined || checklist.maxPoints === 0) {
+      return selectedInstance.weekMaxPoints
+    }
+    return checklist.maxPoints
+  }
+
   const createStudentGradedWeek = (i, week) => (
     <Accordion key={i} fluid styled>
       <Accordion.Title active={i === coursePageLogic.activeIndex} index={i} onClick={handleClick}>
         <Icon name="dropdown" />
-        {i + 1 > selectedInstance.weekAmount ? <span>Final Review</span> : <span>Week {week.weekNumber}</span>}, points {week.points}
+        {i + 1 > selectedInstance.weekAmount ? <span>Final Review</span> : <span>Week {week.weekNumber}</span>}, points {week.points} / {getMaximumPoints(week.weekNumber)}
       </Accordion.Title>
       <Accordion.Content active={i === coursePageLogic.activeIndex}>
         <Card fluid color="yellow">
           <Card.Content>
-            <h4> Points {week.points} </h4>
+            <h4>
+              {' '}
+              Points {week.points} / {getMaximumPoints(week.weekNumber)}
+            </h4>
             <h4> Feedback </h4>
             <ReactMarkdown>{week.feedback}</ReactMarkdown>{' '}
           </Card.Content>

--- a/labtool2.0/src/components/pages/ReviewStudent.js
+++ b/labtool2.0/src/components/pages/ReviewStudent.js
@@ -109,7 +109,7 @@ export const ReviewStudent = props => {
 
   const getMaximumPoints = () => {
     const checklist = props.selectedInstance.checklists.find(checkl => checkl.week === Number(props.ownProps.weekNumber))
-    if (checklist === undefined || !checklist.maxPoints) {
+    if (checklist === undefined || checklist.maxPoints === 0) {
       return props.selectedInstance.weekMaxPoints
     }
     return checklist.maxPoints


### PR DESCRIPTION
### Short description
#761 Maximum points of each week are shown to the student
Also fixes the bug where maximum points were limited by default weekly points instead of the checklist maximum points.

### DoD
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [x] test(s) that actually pass.