### PR TITLE
fix/add comment-accordion can be opened

### DIFF
--- a/labtool2.0/src/components/LabtoolAddComment.js
+++ b/labtool2.0/src/components/LabtoolAddComment.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { Accordion, Button, Form, Icon } from 'semantic-ui-react'
 import { withRouter } from 'react-router'
@@ -11,10 +11,13 @@ export const LabtoolAddComment = ({ commentFieldId, weekId, handleSubmit, allowH
 
   const toggleOpen = () => {
     state.commentOpen = !state.commentOpen
+  }
+
+  useEffect(() => {
     if (!state.commentOpen) {
       state.reset()
     }
-  }
+  }, [state.commentOpen])
 
   const doSubmit = (...args) => {
     state.reset()


### PR DESCRIPTION
### Short description
#785 
Fix the bug that  the Add comment-accordion can't be opened in BrowseReviews-page
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [x] test(s) that actually pass.

