### PR TITLE
Fix copying checklists

### DIFF
--- a/backend/server/controllers/checklists.js
+++ b/backend/server/controllers/checklists.js
@@ -162,6 +162,9 @@ module.exports = {
           const checklistItemCopy = { ...checklistItem }
           delete checklistItemCopy.category
           delete checklistItemCopy.checklistId
+          if (req.body.copying) {
+            delete checklistItemCopy.id
+          }
           checklistJson[checklistItem.category].push(checklistItemCopy)
         })
 

--- a/labtool2.0/src/components/JsonEdit.js
+++ b/labtool2.0/src/components/JsonEdit.js
@@ -45,7 +45,7 @@ const JsonEdit = props => {
 
       <Modal onClose={closeDialog} open={open}>
         <Modal.Header>JSON</Modal.Header>
-        <Modal.Description style={{ padding: 15 }}>Pressing &quot;Save&quot; saves immediately and overwrites the current checklist.</Modal.Description>
+        <Modal.Description style={{ padding: 15 }}>Pressing &quot;Save&quot; saves immediately and overwrites the current checklist. When copying checklists or adding new items, make sure to remove the IDs.</Modal.Description>
         <Modal.Description>
           {state.error && (
             <Message style={{ padding: 15 }} error>


### PR DESCRIPTION
### Short description
It no longer deletes the checklist on the course which we are copying from. JsonEdit also has a note, because it has the same issue (what to do with IDs there?)

### DoD
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [x] test(s) that actually pass.
