### PR TITLE
When reviewing with checklists, maximum points should be week specific

### DIFF
--- a/labtool2.0/src/components/pages/ReviewStudent.js
+++ b/labtool2.0/src/components/pages/ReviewStudent.js
@@ -191,8 +191,8 @@ export const ReviewStudent = props => {
     })
     if (checklistPoints < 0) {
       checklistPoints = 0
-    } else if (checklistPoints > props.selectedInstance.weekMaxPoints) {
-      checklistPoints = props.selectedInstance.weekMaxPoints
+    } else if (checklistPoints > getMaximumPoints()) {
+      checklistPoints = getMaximumPoints()
     }
   }
 


### PR DESCRIPTION
### Short description
#890 When counting checklist points, the points are no more limited by the default weekly maximum points. This also allows giving the review points based on the checklist points correctly. 

### DoD
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [x] test(s) that actually pass.