### PR TITLE
Fix email newlines; fix dropdown cutoff

### DIFF
--- a/backend/server/controllers/email.js
+++ b/backend/server/controllers/email.js
@@ -485,10 +485,10 @@ const buildEmail = (title, link, courseName, pointsAwarded, contentTitle, conten
   <h1>${title}</h1>
   <p><a href="${link}">${link}</a></p>
   <p>course: ${courseName}</p>
-  ${pointsAwarded !== null && `<p>points awarded: ${pointsAwarded}</p>`}
+  ${pointsAwarded !== null ? `<p>points awarded: ${pointsAwarded}</p>` : ''}
   <p><i>This is an automated message sent using the Labtool email tool. Please do not reply to this email.</i></p>
   <h2>${contentTitle}</h2>
-  <p style="white-space: pre-line;">${escape(content)}</p>
+  <p>${escape(content).replace(/\n/g, '<br>')}</p>
 `
 
 module.exports = {

--- a/labtool2.0/src/components/StudentTable/StudentTableRow.js
+++ b/labtool2.0/src/components/StudentTable/StudentTableRow.js
@@ -306,7 +306,7 @@ export const StudentTableRow = props => {
           <div>
             {coursePageLogic.showTagDropdown === data.id ? (
               <div>
-                <Dropdown id={'tagDropdown'} style={{ float: 'left' }} selectOnBlur={false} options={dropDownTags} onChange={addTag(data.id)} placeholder="Choose tag" fluid selection />
+                <Dropdown id={'tagDropdown'} upward={false} style={{ float: 'left' }} selectOnBlur={false} options={dropDownTags} onChange={addTag(data.id)} placeholder="Choose tag" fluid selection />
               </div>
             ) : (
               <div />
@@ -353,6 +353,7 @@ export const StudentTableRow = props => {
                   <Dropdown
                     id={'assistantDropdown'}
                     selectOnBlur={false}
+                    upward={false}
                     options={dropDownTeachers}
                     onChange={updateTeacher(data.id, data.teacherInstanceId)}
                     placeholder="Select teacher"

--- a/labtool2.0/src/components/pages/CoursePage.js
+++ b/labtool2.0/src/components/pages/CoursePage.js
@@ -307,7 +307,7 @@ export const CoursePage = props => {
       bulkMarkInvalid
     }
     return (
-      <div style={{ overflowX: 'auto', overflowY: 'hidden', marginBottom: '20em' }}>
+      <div style={{ overflowX: 'auto', overflowY: 'hidden', marginBottom: '-20em', paddingBottom: '20em' }}>
         <CoursePageTeacherHeader selectedInstance={selectedInstance} courseInstance={courseInstance} activateCourse={activateCourse} moveToNextWeek={moveToNextWeek} />
         <CoursePageTeacherMain
           courseId={courseId}

--- a/labtool2.0/src/tests/__snapshots__/CoursePage.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/CoursePage.test.js.snap
@@ -308,9 +308,10 @@ exports[`<CoursePage /> as teacher CoursePage Component should render correctly 
 <div
   style={
     Object {
-      "marginBottom": "20em",
+      "marginBottom": "-20em",
       "overflowX": "auto",
       "overflowY": "hidden",
+      "paddingBottom": "20em",
     }
   }
 >


### PR DESCRIPTION
### Short description
Fixes some bugs, specifically with email newlines (just use `<br>`) and frontend dropdown cutoffs when using tag/instructor dropdown in the table

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [x] test(s) that actually pass.
