### PR TITLE
fix/show the points if a code review has no link but was graded

### DIFF
--- a/labtool2.0/src/components/StudentTable/StudentTableRow.js
+++ b/labtool2.0/src/components/StudentTable/StudentTableRow.js
@@ -185,10 +185,10 @@ export const StudentTableRow = props => {
               to={{ pathname: `/labtool/browsereviews/${selectedInstance.ohid}/${siId}`, state: { openAllWeeks: true, jumpToReview: codeReview ? `CodeReview${codeReview.reviewNumber}` : undefined } }}
             >
               {shouldReview && selectedInstance.currentCodeReview.includes(index) && codeReview ? (
-                codeReview.linkToReview === null ? (
+                codeReview.linkToReview === null && codeReview.points === null ? (
                   <Popup
                     position="top center"
-                    trigger={<Icon color="grey" size="small" name="hourglass end" fitted />}
+                    trigger={<Icon color="grey" size="large" name="hourglass end" fitted />}
                     content="Student has not yet submitted the code review"
                     className="codeReviewNotReady"
                   />


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
#950 Change the size of the hourglass. Show the points instead of an hourglass if the code review has been graded (although the student didn't add the link). 
### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [x] test(s) that actually pass.

