### PR TITLE
Fix/intuitive max points in checklist

### DIFF
--- a/labtool2.0/src/components/StudentTable.js
+++ b/labtool2.0/src/components/StudentTable.js
@@ -317,8 +317,8 @@ StudentTable.propTypes = {
   selectedInstance: PropTypes.object.isRequired,
   coursePageLogic: PropTypes.object.isRequired,
   tags: PropTypes.object.isRequired,
-  courseData: PropTypes.object.isRequired,
-  loggedInUser: PropTypes.object.isRequired,
+  courseData: PropTypes.object,
+  loggedInUser: PropTypes.object,
 
   associateTeacherToStudent: PropTypes.func.isRequired,
   showAssistantDropdown: PropTypes.func.isRequired,

--- a/labtool2.0/src/components/pages/CoursePage/TeacherHeader.js
+++ b/labtool2.0/src/components/pages/CoursePage/TeacherHeader.js
@@ -73,10 +73,10 @@ export const CoursePageTeacherHeader = props => {
                   state: { cameFromCoursePage: true }
                 }}
               >
-                <Popup trigger={<Button circular size="tiny" icon={{ name: 'shuffle', size: 'large', color: 'orange' }} />} content="Edit code reviews" />
+                <Popup trigger={<Button circular size="tiny" icon={{ name: 'shuffle', size: 'large', color: 'orange' }} />} content="Edit code reviews" position="bottom right" />
               </Link>
               <Link to={`/labtool/ModifyCourseInstancePage/${selectedInstance.ohid}`}>
-                <Popup trigger={<Button circular size="tiny" icon={{ name: 'edit', size: 'large', color: 'orange' }} />} content="Edit course" />
+                <Popup trigger={<Button circular size="tiny" icon={{ name: 'edit', size: 'large', color: 'orange' }} />} content="Edit course" position="top right" />
               </Link>
             </Table.Cell>
           </Table.Row>

--- a/labtool2.0/src/components/pages/CreateChecklist.js
+++ b/labtool2.0/src/components/pages/CreateChecklist.js
@@ -615,21 +615,12 @@ export const CreateChecklist = props => {
                 </p>
               </Card.Content>
               <Card.Content>
-                {currentObj.kind === 'codeReview' ? (
-                  <p>
-                    Maximum points for this code review:{' '}
-                    <strong>
-                      <Points points={state.maximumPoints} />
-                    </strong>
-                  </p>
-                ) : (
-                  <p className="maxPointsForWeek">
-                    Maximum points for this week:{' '}
-                    <strong>
-                      <Points points={getMaximumPointsForWeek()} />
-                    </strong>
-                  </p>
-                )}
+                <p className="maxPointsForWeek">
+                  Maximum points for this review:{' '}
+                  <strong>
+                    {currentObj.kind === 'codeReview' ? state.maximumPoints === '' ? '' : <Points points={Number(state.maximumPoints)} /> : <Points points={getMaximumPointsForWeek()} />}
+                  </strong>
+                </p>
               </Card.Content>
             </Card>
             <div>
@@ -640,7 +631,7 @@ export const CreateChecklist = props => {
                 trigger={<Icon name="question circle" />}
                 content={
                   currentObj.kind === 'week'
-                    ? `The points you define here will be the maximum points for this week. If no value is given, the maximum points for this week 
+                    ? `The points you define here will be the maximum points for this review. If no value is given, the maximum points for this review 
                 will stay the same as the defaulted weekly points which is ${props.selectedInstance.weekMaxPoints}`
                     : 'You need to specify max points for this code review so that the max points can be visible to students'
                 }

--- a/labtool2.0/src/tests/CreateChecklist.test.js
+++ b/labtool2.0/src/tests/CreateChecklist.test.js
@@ -187,7 +187,7 @@ describe('<CreateChecklist /> component', () => {
 
       it('if user adds maximum points, the given points are shown', () => {
         wrapper.find('.maxPointsInput').simulate('change', { target: { value: '5' } })
-        expect(wrapper.find('.maxPointsForWeek').text()).toContain('Maximum points for this week:')
+        expect(wrapper.find('.maxPointsForWeek').text()).toContain('Maximum points for this review:')
         expect(wrapper.find('.maxPointsForWeek Points').prop('points')).toEqual(5)
         wrapper.find('.maxPointsInput').simulate('change', { target: { value: '' } })
       })

--- a/labtool2.0/src/tests/__snapshots__/CreateChecklist.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/CreateChecklist.test.js.snap
@@ -549,7 +549,7 @@ exports[`<CreateChecklist /> component should render correctly 1`] = `
           <p
             className="maxPointsForWeek"
           >
-            Maximum points for this week:
+            Maximum points for this review:
              
             <strong>
               <Points
@@ -577,7 +577,7 @@ exports[`<CreateChecklist /> component should render correctly 1`] = `
         />
         <Popup
           className="infoText"
-          content="The points you define here will be the maximum points for this week. If no value is given, the maximum points for this week 
+          content="The points you define here will be the maximum points for this review. If no value is given, the maximum points for this review 
                 will stay the same as the defaulted weekly points which is 3"
           disabled={false}
           eventsEnabled={true}


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- #953 Use "maximum points for this review" when showing maximum points in the checklist creation page so that we don't need to care about if the checklist is for code review, week review or final review.
- fix the bug that the checklist creation page is broken when using component `<Points />`.
- some small fixes for proptypes
- change the position of the pop up of "Edit code reviews" and "Edit course" in the course page

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [x] added or modified test(s).
- [x] test(s) that actually pass.

