### PR TITLE
Fix tag selection bug on ModifyTags

### DIFF
--- a/labtool2.0/src/components/pages/ManageTags.js
+++ b/labtool2.0/src/components/pages/ManageTags.js
@@ -27,6 +27,10 @@ export const ManageTags = props => {
     props.resetLoading()
     props.getAllTags()
     props.getAllCI()
+
+    return () => {
+      props.willCreateNewTag()
+    }
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
### Short description
#983 
Turns out the bug is more like "the modified tag stays selected even if you exit the page"

### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [x] test(s) that actually pass.
