### PR TITLE
Fix/should be able to delete link to courses page when modifying a course instance

### DIFF
--- a/labtool2.0/src/components/pages/ModifyCourseInstancePage.js
+++ b/labtool2.0/src/components/pages/ModifyCourseInstancePage.js
@@ -90,7 +90,7 @@ export const ModifyCourseInstancePage = props => {
       const { weekAmount, weekMaxPoints, currentWeek, active, ohid, finalReview, coursesPage, courseMaterial } = props.selectedInstance
 
       // This checks that the 'courses.helsinki.fi' URL actually contains that string as a part of it. Reject if not.
-      if (coursesPage !== null) {
+      if (coursesPage !== null && coursesPage !== '') {
         if ((coursesPage.match(/courses.helsinki.fi/g) || []).length === 0) {
           props.showNotification({
             message: 'Link to "courses.helsinki.fi" must have that string as a part of it.',
@@ -260,7 +260,7 @@ export const ModifyCourseInstancePage = props => {
                   <Input
                     name="coursesPage"
                     type="url"
-                    style={{ maxWidth: '12em' }}
+                    style={{ minWidth: '26em' }}
                     value={selectedInstance.coursesPage === null ? '' : selectedInstance.coursesPage}
                     className="form-control4"
                     onChange={changeField}
@@ -272,7 +272,7 @@ export const ModifyCourseInstancePage = props => {
                   <Input
                     name="courseMaterial"
                     type="url"
-                    style={{ maxWidth: '12em' }}
+                    style={{ minWidth: '26em' }}
                     value={selectedInstance.courseMaterial === null ? '' : selectedInstance.courseMaterial}
                     className="form-control5"
                     onChange={changeField}

--- a/labtool2.0/src/tests/__snapshots__/ModifyCourseInstancePage.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/ModifyCourseInstancePage.test.js.snap
@@ -198,7 +198,7 @@ exports[`<ModifyCourseInstancePage /> Modify Instance Component should render co
                 onChange={[Function]}
                 style={
                   Object {
-                    "maxWidth": "12em",
+                    "minWidth": "26em",
                   }
                 }
                 type="url"
@@ -223,7 +223,7 @@ exports[`<ModifyCourseInstancePage /> Modify Instance Component should render co
                 onChange={[Function]}
                 style={
                   Object {
-                    "maxWidth": "12em",
+                    "minWidth": "26em",
                   }
                 }
                 type="url"


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
- fix #1015 
- longer input field for URL when modifying a course instance so that the whole URL can be seen at the same time
### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [x] added or modified test(s).
- [x] test(s) that actually pass.

