### PR TITLE
Use checkbox to set code reviews as visible/unvisible

### DIFF
--- a/labtool2.0/src/components/pages/ModifyCourseInstancePage.js
+++ b/labtool2.0/src/components/pages/ModifyCourseInstancePage.js
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { Form, Input, Button, Grid, Dropdown, Checkbox, Loader, Segment, Label } from 'semantic-ui-react'
+import { Form, Input, Button, Grid, Dropdown, Checkbox, Loader, Segment } from 'semantic-ui-react'
 import { getOneCI, modifyOneCI, coursePageInformation, getAllCI, copyInformationFromCourse } from '../../services/courseInstance'
-import { setFinalReview, setCodeReviewVisible, hideCodeReview } from '../../reducers/selectedInstanceReducer'
+import { setFinalReview } from '../../reducers/selectedInstanceReducer'
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { Redirect } from 'react-router'
@@ -23,7 +23,8 @@ import { CodeReviewCheckbox } from './ModifyCourseInstancePage/CodeReviewCheckbo
  */
 export const ModifyCourseInstancePage = props => {
   const state = useLegacyState({
-    copyCourse: undefined
+    copyCourse: undefined,
+    visibleCr: []
   })
 
   useEffect(() => {
@@ -43,6 +44,10 @@ export const ModifyCourseInstancePage = props => {
       }
     }
   }, [props.selectedInstance.weekAmount, props.selectedInstance.finalReview, props.selectedInstance.currentWeek])
+
+  useEffect(() => {
+    state.visibleCr = props.selectedInstance.currentCodeReview
+  }, [props.selectedInstance.currentCodeReview])
 
   const changeField = e => {
     props.changeCourseField({
@@ -70,12 +75,20 @@ export const ModifyCourseInstancePage = props => {
     props.setFinalReview(newValue)
   }
 
+  const setCodeReviewVisible = value => {
+    state.visibleCr = [...state.visibleCr, value]
+  }
+
+  const hideCodeReview = value => {
+    state.visibleCr = state.visibleCr.filter(cr => cr !== value)
+  }
+
   const handleSubmit = async e => {
     try {
       e.preventDefault()
 
-      const { weekAmount, weekMaxPoints, currentWeek, currentCodeReview, active, ohid, finalReview, coursesPage, courseMaterial } = props.selectedInstance
-      let newCr = currentCodeReview
+      const { weekAmount, weekMaxPoints, currentWeek, active, ohid, finalReview, coursesPage, courseMaterial } = props.selectedInstance
+      let newCr = state.visibleCr
       // This checks that the 'courses.helsinki.fi' URL actually contains that string as a part of it. Reject if not.
       if (coursesPage !== null && coursesPage !== '') {
         if ((coursesPage.match(/courses.helsinki.fi/g) || []).length === 0) {
@@ -274,8 +287,8 @@ export const ModifyCourseInstancePage = props => {
                         <div key={cr.value} className={`cr${cr.value}`}>
                           <CodeReviewCheckbox
                             codeReview={cr}
-                            setCodeReviewVisible={props.setCodeReviewVisible}
-                            hideCodeReview={props.hideCodeReview}
+                            setCodeReviewVisible={setCodeReviewVisible}
+                            hideCodeReview={hideCodeReview}
                             initialCheckState={props.selectedInstance.currentCodeReview.includes(cr.value)}
                           />
                         </div>
@@ -401,9 +414,7 @@ const mapDispatchToProps = {
   resetLoading,
   addRedirectHook,
   setFinalReview,
-  forceRedirect,
-  setCodeReviewVisible,
-  hideCodeReview
+  forceRedirect
 }
 
 ModifyCourseInstancePage.propTypes = {
@@ -428,9 +439,7 @@ ModifyCourseInstancePage.propTypes = {
   resetLoading: PropTypes.func.isRequired,
   addRedirectHook: PropTypes.func.isRequired,
   setFinalReview: PropTypes.func.isRequired,
-  forceRedirect: PropTypes.func.isRequired,
-  setCodeReviewVisible: PropTypes.func.isRequired,
-  hideCodeReview: PropTypes.func.isRequired
+  forceRedirect: PropTypes.func.isRequired
 }
 
 export default connect(

--- a/labtool2.0/src/components/pages/ModifyCourseInstancePage/CodeReviewCheckbox.js
+++ b/labtool2.0/src/components/pages/ModifyCourseInstancePage/CodeReviewCheckbox.js
@@ -1,0 +1,29 @@
+import React, { useState } from 'react'
+import { Checkbox, Segment } from 'semantic-ui-react'
+import PropTypes from 'prop-types'
+
+export const CodeReviewCheckbox = props => {
+  const { setCodeReviewVisible, hideCodeReview, initialCheckState, codeReview } = props
+  const [checked, setChecked] = useState(initialCheckState)
+
+  const handleCheckChange = value => (e, { checked }) => {
+    if (checked) {
+      setCodeReviewVisible(value)
+    } else {
+      hideCodeReview(value)
+    }
+    setChecked(checked)
+  }
+  return (
+    <Segment vertical>
+      <Checkbox label={codeReview.text} checked={checked} onChange={handleCheckChange(codeReview.value)} />
+    </Segment>
+  )
+}
+
+CodeReviewCheckbox.propTypes = {
+  setCodeReviewVisible: PropTypes.func.isRequired,
+  hideCodeReview: PropTypes.func.isRequired,
+  initialCheckState: PropTypes.bool.isRequired,
+  codeReview: PropTypes.object.isRequired
+}

--- a/labtool2.0/src/reducers/selectedInstanceReducer.js
+++ b/labtool2.0/src/reducers/selectedInstanceReducer.js
@@ -11,6 +11,7 @@
   currentWeek(pin): -- integer, what is the current week
   ohid(pin): -- Opetushallitus id of the course, is often used instead of the database id
   teacherInstances: all the teacherinstances related to his course instance
+  currentCodeReview: Array of code reviews which are visible to students
  * 
  */
 
@@ -37,6 +38,10 @@ const selectedInstanceReducer = (store = INITIAL_STATE, action) => {
       return { ...store, finalReview: action.value }
     case 'CI_MODIFY_ONE_SUCCESS':
       return { ...store, ...action.response, currentWeek: Number(action.response.currentWeek || store.currentWeek, 10) }
+    case 'SET_CR_VISIBLE':
+      return { ...store, currentCodeReview: store.currentCodeReview.concat(action.value) }
+    case 'HIDE_CR':
+      return { ...store, currentCodeReview: store.currentCodeReview.filter(cr => cr !== action.value) }
     default:
       return store
   }
@@ -56,6 +61,24 @@ export const changeCourseField = data => {
     dispatch({
       type: 'SI_CHANGE_FIELD',
       data
+    })
+  }
+}
+
+export const setCodeReviewVisible = value => {
+  return async dispatch => {
+    dispatch({
+      type: 'SET_CR_VISIBLE',
+      value
+    })
+  }
+}
+
+export const hideCodeReview = value => {
+  return async dispatch => {
+    dispatch({
+      type: 'HIDE_CR',
+      value
     })
   }
 }

--- a/labtool2.0/src/reducers/selectedInstanceReducer.js
+++ b/labtool2.0/src/reducers/selectedInstanceReducer.js
@@ -38,10 +38,6 @@ const selectedInstanceReducer = (store = INITIAL_STATE, action) => {
       return { ...store, finalReview: action.value }
     case 'CI_MODIFY_ONE_SUCCESS':
       return { ...store, ...action.response, currentWeek: Number(action.response.currentWeek || store.currentWeek, 10) }
-    case 'SET_CR_VISIBLE':
-      return { ...store, currentCodeReview: store.currentCodeReview.concat(action.value) }
-    case 'HIDE_CR':
-      return { ...store, currentCodeReview: store.currentCodeReview.filter(cr => cr !== action.value) }
     default:
       return store
   }
@@ -61,24 +57,6 @@ export const changeCourseField = data => {
     dispatch({
       type: 'SI_CHANGE_FIELD',
       data
-    })
-  }
-}
-
-export const setCodeReviewVisible = value => {
-  return async dispatch => {
-    dispatch({
-      type: 'SET_CR_VISIBLE',
-      value
-    })
-  }
-}
-
-export const hideCodeReview = value => {
-  return async dispatch => {
-    dispatch({
-      type: 'HIDE_CR',
-      value
     })
   }
 }

--- a/labtool2.0/src/tests/ModifyCourseInstancePage.test.js
+++ b/labtool2.0/src/tests/ModifyCourseInstancePage.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ModifyCourseInstancePage } from '../components/pages/ModifyCourseInstancePage'
 import { shallow } from 'enzyme'
-import { Popup, Checkbox } from 'semantic-ui-react'
+import { Checkbox } from 'semantic-ui-react'
 
 describe('<ModifyCourseInstancePage />', () => {
   let wrapper
@@ -16,8 +16,8 @@ describe('<ModifyCourseInstancePage />', () => {
     weekMaxPoints: 2,
     currentWeek: 1,
     ohid: 'TKT20011.2018.K.A.1',
-    currentCodeReview: [1, 2],
-    amountOfCodeReviews: 3
+    currentCodeReview: [1],
+    amountOfCodeReviews: 2
   }
 
   const loading = {
@@ -30,10 +30,12 @@ describe('<ModifyCourseInstancePage />', () => {
 
   let mockFn = jest.fn()
 
+  const codeReviewLabels = [{ value: 1, text: 'Code Review 1' }, { value: 2, text: 'Code Review 2' }]
+
   beforeEach(() => {
     wrapper = shallow(
       <ModifyCourseInstancePage
-        codeReviewDropdowns={[{ value: 3, text: '3' }]}
+        codeReviewLabels={codeReviewLabels}
         getOneCI={mockFn}
         clearNotifications={mockFn}
         loading={loading}
@@ -51,6 +53,8 @@ describe('<ModifyCourseInstancePage />', () => {
         getAllCI={mockFn}
         coursePageInformation={mockFn}
         copyInformationFromCourse={mockFn}
+        setCodeReviewVisible={mockFn}
+        hideCodeReview={mockFn}
       />
     )
   })
@@ -79,25 +83,22 @@ describe('<ModifyCourseInstancePage />', () => {
     it('renders current week', () => {
       expect(wrapper.find('.weekDropdown').length).toEqual(1)
     })
-    it('renders currently visible code reviews', () => {
-      expect(
-        wrapper
-          .find(Popup)
-          .at(0)
-          .props().trigger.props.value
-      ).toEqual(1)
-      expect(
-        wrapper
-          .find(Popup)
-          .at(1)
-          .props().trigger.props.value
-      ).toEqual(2)
+
+    it('renders code review checkboxes', () => {
+      expect(wrapper.find('.crCheckboxes').exists()).toEqual(true)
+      const visibleCr = wrapper
+        .find('.crCheckboxes')
+        .find('.cr1')
+        .find('CodeReviewCheckbox')
+      expect(visibleCr.props().initialCheckState).toEqual(true)
+
+      const hiddenCr = wrapper
+        .find('.crCheckboxes')
+        .find('.cr2')
+        .find('CodeReviewCheckbox')
+      expect(hiddenCr.props().initialCheckState).toEqual(false)
     })
 
-    it('renders dropdown to show currently not visible code reviews', () => {
-      expect(wrapper.find('.codeReviewDropdown').length).toEqual(1)
-      expect(wrapper.find('.codeReviewDropdown').props().options[0].text).toEqual('3')
-    })
     it('renders active course checkbox', () => {
       const checkbox = wrapper.find(Checkbox).find({ name: 'courseActive' })
 

--- a/labtool2.0/src/tests/ModifyCourseInstancePage.test.js
+++ b/labtool2.0/src/tests/ModifyCourseInstancePage.test.js
@@ -53,8 +53,6 @@ describe('<ModifyCourseInstancePage />', () => {
         getAllCI={mockFn}
         coursePageInformation={mockFn}
         copyInformationFromCourse={mockFn}
-        setCodeReviewVisible={mockFn}
-        hideCodeReview={mockFn}
       />
     )
   })

--- a/labtool2.0/src/tests/__snapshots__/ModifyCourseInstancePage.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/ModifyCourseInstancePage.test.js.snap
@@ -262,9 +262,9 @@ exports[`<ModifyCourseInstancePage /> Modify Instance Component should render co
                         "value": 1,
                       }
                     }
-                    hideCodeReview={[MockFunction]}
+                    hideCodeReview={[Function]}
                     initialCheckState={true}
-                    setCodeReviewVisible={[MockFunction]}
+                    setCodeReviewVisible={[Function]}
                   />
                 </div>
                 <div
@@ -278,9 +278,9 @@ exports[`<ModifyCourseInstancePage /> Modify Instance Component should render co
                         "value": 2,
                       }
                     }
-                    hideCodeReview={[MockFunction]}
+                    hideCodeReview={[Function]}
                     initialCheckState={false}
-                    setCodeReviewVisible={[MockFunction]}
+                    setCodeReviewVisible={[Function]}
                   />
                 </div>
               </Segment>

--- a/labtool2.0/src/tests/__snapshots__/ModifyCourseInstancePage.test.js.snap
+++ b/labtool2.0/src/tests/__snapshots__/ModifyCourseInstancePage.test.js.snap
@@ -240,92 +240,50 @@ exports[`<ModifyCourseInstancePage /> Modify Instance Component should render co
                   }
                 }
               >
-                Currently visible code reviews
+                Visible code reviews
               </label>
-              <Popup
-                content="Click to hide this code review on save"
-                disabled={false}
-                eventsEnabled={true}
-                key="1"
-                offset={0}
-                on={
-                  Array [
-                    "click",
-                    "hover",
-                  ]
+              <Segment
+                className="crCheckboxes"
+                style={
+                  Object {
+                    "maxHeight": 200,
+                    "overflow": "auto",
+                  }
                 }
-                pinned={false}
-                position="top left"
-                trigger={
-                  <Button
-                    as="button"
-                    compact={true}
-                    onClick={[Function]}
-                    value={1}
-                  >
-                    1
-                  </Button>
-                }
-              />
-              <Popup
-                content="Click to hide this code review on save"
-                disabled={false}
-                eventsEnabled={true}
-                key="2"
-                offset={0}
-                on={
-                  Array [
-                    "click",
-                    "hover",
-                  ]
-                }
-                pinned={false}
-                position="top left"
-                trigger={
-                  <Button
-                    as="button"
-                    compact={true}
-                    onClick={[Function]}
-                    value={2}
-                  >
-                    2
-                  </Button>
-                }
-              />
-            </FormGroup>
-            <FormGroup
-              inline={true}
-            >
-              <Dropdown
-                additionLabel="Add "
-                additionPosition="top"
-                className="codeReviewDropdown"
-                closeOnBlur={true}
-                closeOnEscape={true}
-                deburr={false}
-                fluid={true}
-                icon="dropdown"
-                minCharacters={1}
-                multiple={true}
-                noResultsMessage="No results found."
-                onChange={[Function]}
-                openOnFocus={true}
-                options={
-                  Array [
-                    Object {
-                      "text": "3",
-                      "value": 3,
-                    },
-                  ]
-                }
-                placeholder="Select code reviews to set visible"
-                renderLabel={[Function]}
-                searchInput="text"
-                selectOnBlur={true}
-                selectOnNavigation={true}
-                selection={true}
-                wrapSelection={true}
-              />
+              >
+                <div
+                  className="cr1"
+                  key="1"
+                >
+                  <CodeReviewCheckbox
+                    codeReview={
+                      Object {
+                        "text": "Code Review 1",
+                        "value": 1,
+                      }
+                    }
+                    hideCodeReview={[MockFunction]}
+                    initialCheckState={true}
+                    setCodeReviewVisible={[MockFunction]}
+                  />
+                </div>
+                <div
+                  className="cr2"
+                  key="2"
+                >
+                  <CodeReviewCheckbox
+                    codeReview={
+                      Object {
+                        "text": "Code Review 2",
+                        "value": 2,
+                      }
+                    }
+                    hideCodeReview={[MockFunction]}
+                    initialCheckState={false}
+                    setCodeReviewVisible={[MockFunction]}
+                  />
+                </div>
+              </Segment>
             </FormGroup>
             <FormGroup
               inline={true}


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
#1012 Improve the UI of setting code reviews as visible/unvisible by using checkboxes. 
### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [x] added or modified test(s).
- [x] test(s) that actually pass.
