### PR TITLE
back button should navigate to editing page after json modification

### DIFF
--- a/labtool2.0/src/components/pages/CreateChecklist.js
+++ b/labtool2.0/src/components/pages/CreateChecklist.js
@@ -41,6 +41,7 @@ export const CreateChecklist = props => {
     } else {
       props.resetChecklist()
     }
+    props.getOneCI(props.courseId)
     props.getAllCI()
   }, [])
 


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Fix the bug that the `Back to editing course` button doesn't navigate to the course editing page after modifying checklists in JSON. 
### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [x] test(s) that actually pass.

