### PR TITLE
fix/unactive email text field when filter tags

### DIFF
--- a/labtool2.0/src/components/TagLabel.js
+++ b/labtool2.0/src/components/TagLabel.js
@@ -66,6 +66,7 @@ export const TagLabel = props => {
 
   return (
     <Button
+      type="button"
       compact
       basic={basic}
       color={validColors.includes(tagColor) ? tagColor : null}


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
Fix the bug that the email text field is always activated when filtering tags. 
### DoD
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] added actual code.
- [x] produced clean code that passes ESLint.
- [x] code that actually does what it should.
- [ ] documented the code or added documentation to the wiki.
- [ ] added or modified test(s).
- [x] test(s) that actually pass.
